### PR TITLE
Add rewrites to new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,8 @@ s.Gauge(1.0, "my.silly.status", "green")
 If you use a standard UDP connection to a statsd server, all 'update'-class
 functions are goroutine safe. They should return quickly, but they're safe to
 fire in a seperate goroutine.
+
+# Upgrading API
+
+Upgrade to the latest API by running `./fix.bash *.go` where `*.go` expands to
+the paths of the source files you'd like to rewrite to the new API.

--- a/fix.bash
+++ b/fix.bash
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Applies transformations to source trees to keep up to date with
+# with the external API.
+#
+if [ -z "$@" ]; then
+  echo "Usage: $0 path/to/package"
+  exit 1
+fi
+
+gofmt \
+  -r 'NewStatsd(a) -> Dial("udp",a)' \
+  -r 'UpdateGague(a,b) -> Gauge(1.0,a,b)' \
+  -r 'UpdateSampledGaguge(a,b,c) -> Gauge(c,a,b)' \
+  -r 'SendTiming(a,b) -> Timing(1.0,a,b)' \
+  -r 'SendSampledTiming(a,b,c) -> Timing(c,a,b)' \
+  -r 'IncrementCounter(a,b) -> Count(1.0,a,b)' \
+  -r 'IncrementSampledCounter(a,b,c) -> Count(c,a,b)' \
+  -w $@


### PR DESCRIPTION
Run `fix.bash` against source or test files that you wish to format and rewrite to use the new API.

Aka, being a good citizen by providing refactoring rules with API changes.
