### PR TITLE
Allow sampling only for Counters

### DIFF
--- a/types.go
+++ b/types.go
@@ -37,7 +37,7 @@ type timingUpdate struct {
 }
 
 func (u *timingUpdate) Message() string {
-	return fmt.Sprintf("%s:%d|ms%s\n", u.bucket, u.ms, u.sampling.Suffix())
+	return fmt.Sprintf("%s:%d|ms\n", u.bucket, u.ms)
 }
 
 type gaugeUpdate struct {
@@ -47,5 +47,5 @@ type gaugeUpdate struct {
 }
 
 func (u *gaugeUpdate) Message() string {
-	return fmt.Sprintf("%s:%s|g%s\n", u.bucket, u.val, u.sampling.Suffix())
+	return fmt.Sprintf("%s:%s|g\n", u.bucket, u.val)
 }


### PR DESCRIPTION
StatsD olny allows sampling on Counter metrics. To avoid creating invalid packages packages[0] this change-set adjusts the interfaces of the two mehtods in question.

[0] Illegal sampling factor for non-counter metric on line timer:0|ms|@0.050000
